### PR TITLE
Fix role desync between public.users and auth metadata

### DIFF
--- a/scripts/manage-roles.ts
+++ b/scripts/manage-roles.ts
@@ -56,9 +56,21 @@ async function main() {
       process.exit(1);
     }
 
-    console.log(`\nSelected User: ${selectedUser.email}`);
-    const nextRole = selectedUser.role === "chapter_admin" ? "coach" : "chapter_admin";
-    
+    console.log(`\nSelected User: ${selectedUser.email} (current role: ${selectedUser.role})`);
+    const validRoles = ["platform_admin", "chapter_admin", "content_creator", "coach", "public_visitor"];
+    console.log(`Available roles: ${validRoles.join(", ")}`);
+    const nextRole = await rl.question("Enter new role: ");
+
+    if (!validRoles.includes(nextRole)) {
+      console.log(`Invalid role. Must be one of: ${validRoles.join(", ")}`);
+      process.exit(1);
+    }
+
+    if (nextRole === selectedUser.role) {
+      console.log("Role is already set to that value.");
+      process.exit(0);
+    }
+
     const confirm = await rl.question(`Switch role from '${selectedUser.role}' to '${nextRole}'? (y/n): `);
     if (confirm.toLowerCase() !== 'y') {
       console.log("Aborted.");
@@ -75,10 +87,10 @@ async function main() {
       throw new Error(`Failed to update public.users: ${updateError.message}`);
     }
 
-    // 2. Update auth.users metadata to keep it in sync for JWT/Session
+    // 2. Update auth.users app_metadata to keep it in sync for JWT/Session
     const { error: authError } = await supabase.auth.admin.updateUserById(
       selectedUser.id,
-      { user_metadata: { role: nextRole } }
+      { app_metadata: { role: nextRole } }
     );
 
     if (authError) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -76,19 +76,27 @@ export const getCurrentUser = cache(async () => {
       .eq("id", user.id)
       .maybeSingle();
 
+    const metadataRole = coerceRole(
+      typeof user.app_metadata?.role === "string"
+        ? user.app_metadata.role
+        : null,
+    );
+
     if (data) {
-      return mapProfileRow(data);
+      const profile = mapProfileRow(data);
+      // app_metadata is authoritative (only service_role can set it).
+      // If it carries a non-default role that differs from the DB row, prefer it.
+      if (metadataRole !== "public_visitor" && metadataRole !== profile.role) {
+        return { ...profile, role: metadataRole };
+      }
+      return profile;
     }
 
     return {
       id: user.id,
       email: user.email ?? "",
       name: typeof user.user_metadata?.name === "string" ? user.user_metadata.name : "",
-      role: coerceRole(
-        typeof user.app_metadata?.role === "string"
-          ? user.app_metadata.role
-          : null,
-      ),
+      role: metadataRole,
       chapterId:
         typeof user.app_metadata?.chapter_id === "string"
           ? user.app_metadata.chapter_id

--- a/supabase/migrations/20260410000000_sync_role_from_auth_metadata.sql
+++ b/supabase/migrations/20260410000000_sync_role_from_auth_metadata.sql
@@ -1,0 +1,89 @@
+-- Fix coerce_app_role: add missing content_creator case
+create or replace function public.coerce_app_role(candidate text)
+returns public.app_role
+language sql
+immutable
+as $$
+  select case candidate
+    when 'platform_admin' then 'platform_admin'::public.app_role
+    when 'chapter_admin' then 'chapter_admin'::public.app_role
+    when 'content_creator' then 'content_creator'::public.app_role
+    when 'coach' then 'coach'::public.app_role
+    when 'public_visitor' then 'public_visitor'::public.app_role
+    when 'admin' then 'platform_admin'::public.app_role
+    when 'moderator' then 'chapter_admin'::public.app_role
+    else 'public_visitor'::public.app_role
+  end;
+$$;
+
+-- Trigger: sync app_metadata role changes back to public.users
+-- (reverse direction of existing sync_auth_user_role)
+create or replace function public.sync_role_from_auth_metadata()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  old_role text;
+  new_role text;
+  resolved_role public.app_role;
+  new_chapter_id uuid;
+begin
+  old_role := coalesce(old.raw_app_meta_data ->> 'role', '');
+  new_role := coalesce(new.raw_app_meta_data ->> 'role', '');
+
+  if old_role = new_role then
+    return new;
+  end if;
+
+  resolved_role := public.coerce_app_role(new_role);
+  new_chapter_id := public.parse_uuid(new.raw_app_meta_data ->> 'chapter_id');
+
+  update public.users
+  set
+    role = resolved_role,
+    chapter_id = coalesce(new_chapter_id, public.users.chapter_id)
+  where id = new.id;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_role_synced on auth.users;
+create trigger on_auth_user_role_synced
+after update of raw_app_meta_data on auth.users
+for each row execute procedure public.sync_role_from_auth_metadata();
+
+-- Reverse trigger: sync public.users.role changes back to auth.users.app_metadata
+-- (covers edits made via Table Editor or direct SQL on public.users)
+create or replace function public.sync_role_to_auth_metadata()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.role = new.role then
+    return new;
+  end if;
+
+  perform public.sync_auth_user_role(new.id, new.role, new.chapter_id);
+  return new;
+end;
+$$;
+
+drop trigger if exists on_public_user_role_synced on public.users;
+create trigger on_public_user_role_synced
+after update of role on public.users
+for each row execute procedure public.sync_role_to_auth_metadata();
+
+-- One-time data repair: sync public.users.role from auth.users.app_metadata
+-- for any rows where app_metadata has an explicit non-default role that differs
+update public.users u
+set role = public.coerce_app_role(au.raw_app_meta_data ->> 'role')
+from auth.users au
+where au.id = u.id
+  and au.raw_app_meta_data ->> 'role' is not null
+  and au.raw_app_meta_data ->> 'role' <> ''
+  and u.role::text <> au.raw_app_meta_data ->> 'role';


### PR DESCRIPTION
## Summary
- `getCurrentUser()` now prefers `app_metadata.role` when it carries an explicit non-default value, fixing the case where editing the role in Supabase didn't take effect
- New bidirectional sync triggers keep `public.users.role` and `auth.users.app_metadata.role` in sync regardless of which side is edited
- `coerce_app_role()` SQL function updated to include `content_creator`
- `manage-roles.ts` fixed: writes to `app_metadata` (was `user_metadata`), supports all 5 roles

## Test plan
- [ ] Register user → change role in Table Editor → log out/in → correct role applies
- [ ] Change role in auth.users app_metadata → public.users.role auto-syncs
- [ ] Change role in public.users → auth.users app_metadata auto-syncs
- [ ] `npm run manage:roles` works with all 5 role options

🤖 Generated with [Claude Code](https://claude.com/claude-code)